### PR TITLE
Align DAG expansion with original input context

### DIFF
--- a/dag_generator.py
+++ b/dag_generator.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import os
 from dataclasses import dataclass, field
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 try:
     from openai import AsyncOpenAI
@@ -51,14 +51,27 @@ SYSTEM_PROMPT = (
 )
 
 
-async def expand_node(client: "AsyncOpenAI", node: str) -> Tuple[str, List[str]]:
-    """Ask the model to expand a single node."""
+async def expand_node(
+    client: "AsyncOpenAI", base_input: str, node: Optional[str]
+) -> Tuple[str, List[str]]:
+    """Ask the model to expand a single node.
+
+    The model always receives the original ``base_input`` along with the
+    ``node`` being expanded to mirror the flow:
+        system prompt + input text + new obj -> function call
+    """
+    messages = [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "user", "content": base_input},
+    ]
+    parent = base_input
+    if node is not None:
+        messages.append({"role": "user", "content": node})
+        parent = node
+
     completion = await client.chat.completions.create(
         model="gpt-4o-mini",
-        messages=[
-            {"role": "system", "content": SYSTEM_PROMPT},
-            {"role": "user", "content": node},
-        ],
+        messages=messages,
         functions=FUNCTIONS,
         function_call="auto",
     )
@@ -69,8 +82,8 @@ async def expand_node(client: "AsyncOpenAI", node: str) -> Tuple[str, List[str]]
     payload = json.loads(arguments)
 
     if name == "new_edges":
-        return node, payload.get("children", [])
-    return node, []
+        return parent, payload.get("children", [])
+    return parent, []
 
 
 async def build_dag(seeds: List[str], max_nodes: int = 50) -> DAG:
@@ -78,19 +91,20 @@ async def build_dag(seeds: List[str], max_nodes: int = 50) -> DAG:
         raise RuntimeError("openai package is required to run this script")
     client = AsyncOpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
     dag = DAG()
-    queue = list(seeds)
-    seen = set(queue)
+    queue: List[Tuple[str, Optional[str]]] = [(seed, None) for seed in seeds]
+    seen = set(seeds)
 
     while queue and len(dag.edges) < max_nodes:
-        tasks = [expand_node(client, node) for node in queue]
+        tasks = [expand_node(client, base, node) for base, node in queue]
         results = await asyncio.gather(*tasks)
-        queue = []
-        for parent, children in results:
+        new_queue: List[Tuple[str, Optional[str]]] = []
+        for (base, _), (parent, children) in zip(queue, results):
             for child in children:
                 if child not in seen:
                     seen.add(child)
-                    queue.append(child)
+                    new_queue.append((base, child))
                 dag.add_edge(parent, child)
+        queue = new_queue
     return dag
 
 


### PR DESCRIPTION
## Summary
- ensure each node expansion includes the original input text alongside the new object
- restructure DAG builder queue to track original input and expanded node together

## Testing
- `python -m py_compile dag_generator.py`
- `python dag_generator.py foo` *(fails: openai package is required)*

------
https://chatgpt.com/codex/tasks/task_e_68be0b102d0483249e545b887c7b5636