### PR TITLE
Fix tool definition for OpenAI responses API

### DIFF
--- a/dag_generator.py
+++ b/dag_generator.py
@@ -72,7 +72,7 @@ async def expand_node(
     response = await client.responses.create(
         model="gpt-4o-mini",
         input=messages,
-        tools=[{"type": "function", "function": f} for f in FUNCTIONS],
+        tools=[{**f, "type": "function"} for f in FUNCTIONS],
         tool_choice="auto",
     )
 


### PR DESCRIPTION
## Summary
- Adjust OpenAI tool specification to include function names

## Testing
- `OPENAI_API_KEY=dummy python3 dag_generator.py 'hi'` *(fails: Incorrect API key provided)*

------
https://chatgpt.com/codex/tasks/task_e_68bf37b832508324821102103d920cac