### PR TITLE
feat: allow seeds from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # axioms
-a
+
+Utility script for generating a small directed acyclic graph (DAG) using
+OpenAI's function calling API.
+
+## Usage
+
+```bash
+python dag_generator.py "root node"
+```
+
+The script now also accepts seed prompts from a file using the `--seed-file`
+flag. Each line in the file is treated as a separate seed node:
+
+```bash
+python dag_generator.py --seed-file seeds.txt
+```


### PR DESCRIPTION
## Summary
- allow providing DAG seed prompts via `--seed-file`
- document file-based seeds usage

## Testing
- `python -m py_compile dag_generator.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf3cd2ad888324af10e479cd57803f