### PR TITLE
Add depth and fanout limits to DAG generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,12 @@ flag. Each line in the file is treated as a separate seed node:
 ```bash
 python dag_generator.py --seed-file seeds.txt
 ```
+
+You can further control the graph generation using additional flags:
+
+```bash
+python dag_generator.py "root node" --max-depth 3 --max-fanout 2
+```
+
+* `--max-depth` limits how deep the expansion proceeds (0 disables expansion).
+* `--max-fanout` restricts the number of children added per node.


### PR DESCRIPTION
## Summary
- allow limiting expansion depth and fanout when building DAGs
- expose `--max-depth` and `--max-fanout` command-line options
- update documentation with new flags

## Testing
- `python dag_generator.py --help`
- `python dag_generator.py root --max-depth 1 --max-fanout 2` *(fails: openai package is required)*

------
https://chatgpt.com/codex/tasks/task_e_68bf3f71ed488324b14207f67d256f47