### PR TITLE
Add live layer status to DAG generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,7 @@ python dag_generator.py "root node" --max-depth 3 --max-fanout 2
 
 * `--max-depth` limits how deep the expansion proceeds (0 disables expansion).
 * `--max-fanout` restricts the number of children added per node.
+
+During execution the script prints a live status to stderr showing the
+current layer being expanded and the number of nodes remaining in that
+layer.


### PR DESCRIPTION
## Summary
- show live layer progress with in-flight node counts
- announce newly discovered layers during DAG construction
- document live status behavior in README

## Testing
- `python -m py_compile dag_generator.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf436f913c8324a847b642e60c4dd0