### PR TITLE
Treat seed file as single seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ OpenAI's function calling API.
 python dag_generator.py "root node"
 ```
 
-The script now also accepts seed prompts from a file using the `--seed-file`
-flag. Each line in the file is treated as a separate seed node:
+The script now also accepts a seed prompt from a file using the `--seed-file`
+flag. The entire contents of the file are treated as a single seed node:
 
 ```bash
 python dag_generator.py --seed-file seeds.txt

--- a/dag_generator.py
+++ b/dag_generator.py
@@ -194,7 +194,7 @@ def main() -> None:
     parser.add_argument(
         "--seed-file",
         type=argparse.FileType("r"),
-        help="Path to a file containing seed nodes, one per line",
+        help="Path to a file whose entire contents form a single seed node",
     )
     parser.add_argument(
         "--max-nodes", type=int, default=50, help="Maximum number of nodes to generate"
@@ -216,7 +216,9 @@ def main() -> None:
     seeds = list(args.seed)
     if args.seed_file:
         with args.seed_file as f:
-            seeds.extend(line.strip() for line in f if line.strip())
+            content = f.read().strip()
+            if content:
+                seeds.append(content)
 
     if not seeds:
         parser.error("No seeds provided. Specify positional seeds or use --seed-file.")


### PR DESCRIPTION
## Summary
- Parse `--seed-file` as a single seed instead of line-by-line
- Clarify seed file usage in README and CLI help

## Testing
- `python dag_generator.py --help`
- `python -m py_compile dag_generator.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf447b4e9c8324a7e1747ab6d00c6c