### PR TITLE
Ensure DAG expansion issues only one function call per node

### DIFF
--- a/dag_generator.py
+++ b/dag_generator.py
@@ -96,7 +96,8 @@ FUNCTIONS = [
 SYSTEM_PROMPT = (
     "You expand nodes in a directed acyclic graph. "
     "Use the 'stop_expansion' function when no further ideas are needed. "
-    "Use 'new_edges' to suggest new child nodes to explore."
+    "Use 'new_edges' to suggest new child nodes to explore. "
+    "For each node, call exactly one function: either 'new_edges' or 'stop_expansion'."
 )
 
 
@@ -116,6 +117,7 @@ async def expand_layer(
         input=messages,
         tools=[{**f, "type": "function"} for f in FUNCTIONS],
         tool_choice="auto",
+        parallel_tool_calls=False,
     )
 
     expansions: Dict[str, List[str]] = {}


### PR DESCRIPTION
## Summary
- Clarify system instructions so each node triggers exactly one function call
- Disable parallel tool calls to avoid multiple tool responses in a single step

## Testing
- `python -m py_compile dag_generator.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf694e9a8083249d4e1ae95c52803d