### PR TITLE
Add CLI option for selecting OpenAI model

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ python dag_generator.py "root node" --max-depth 3 --max-fanout 2
 
 * `--max-depth` limits how deep the expansion proceeds (0 disables expansion).
 * `--max-fanout` restricts the number of children added per node.
+* `--model` selects the OpenAI model to use (default `gpt-4o-mini`).
 
 During execution the script prints a live status to stderr showing the
 current layer being expanded and the number of nodes remaining in that


### PR DESCRIPTION
## Summary
- allow specifying the OpenAI model with a new `--model` CLI flag
- propagate the chosen model through `build_dag` and `expand_layer`
- document the `--model` option in the README

## Testing
- `python -m py_compile dag_generator.py`
- `python dag_generator.py "test" --max-depth 0 --model gpt-4o-mini`


------
https://chatgpt.com/codex/tasks/task_e_68bf6d79b6508324afc4b859bc69215a