### PR TITLE
Use IDs for DAG nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,13 @@ OpenAI's function calling API.
 ## Usage
 
 ```bash
-python dag_generator.py "root node"
+python dag_generator.py "ROOT: root node"
 ```
 
-The script now also accepts a seed prompt from a file using the `--seed-file`
-flag. The entire contents of the file are treated as a single seed node:
+Each seed must include a unique identifier followed by a colon and the node
+text (e.g. `ROOT: root node`). The script also accepts a seed prompt from a
+file using the `--seed-file` flag. The entire contents of the file are treated
+as a single seed node:
 
 ```bash
 python dag_generator.py --seed-file seeds.txt


### PR DESCRIPTION
## Summary
- Track DAG nodes with explicit `id` and text pairs
- Require `node_id` and child objects in function schema and prompt
- Accept seeds as `ID: text` and build DAG edges using these identifiers

## Testing
- `python -m py_compile dag_generator.py`
- `python dag_generator.py "ROOT: test" --max-depth 0` *(fails: RuntimeError: openai package is required to run this script)*

------
https://chatgpt.com/codex/tasks/task_e_68c07220a3a48324b8a25f300b99d7f3