### PR TITLE
Allow seeds from stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ node:
 python dag_generator.py --seed-file seeds.txt
 ```
 
+Alternatively, pass the seed via standard input using the `--seed-stdin` flag:
+
+```bash
+echo "root node" | python dag_generator.py --seed-stdin
+```
+
 You can further control the graph generation using additional flags:
 
 ```bash

--- a/dag_generator.py
+++ b/dag_generator.py
@@ -340,6 +340,11 @@ def main() -> None:
         help="Path to a file whose entire contents form a single seed node",
     )
     parser.add_argument(
+        "--seed-stdin",
+        action="store_true",
+        help="Read a seed from standard input",
+    )
+    parser.add_argument(
         "--max-nodes", type=int, default=50, help="Maximum number of nodes to generate"
     )
     parser.add_argument(
@@ -370,9 +375,15 @@ def main() -> None:
             content = f.read().strip()
             if content:
                 seeds.append(parse_seed(content))
+    if args.seed_stdin:
+        content = sys.stdin.read().strip()
+        if content:
+            seeds.append(parse_seed(content))
 
     if not seeds:
-        parser.error("No seeds provided. Specify positional seeds or use --seed-file.")
+        parser.error(
+            "No seeds provided. Specify positional seeds or use --seed-file or --seed-stdin."
+        )
 
     dag = asyncio.run(
         build_dag(


### PR DESCRIPTION
## Summary
- allow reading a seed node from standard input via `--seed-stdin`
- document stdin-based seeding in README

## Testing
- `python -m py_compile dag_generator.py`
- `python dag_generator.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68c07b93f3f88324bd5df32ce8349b02