### PR TITLE
feat: allow appending system prompt from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ python dag_generator.py "root node" --max-depth 3 --max-fanout 2
 * `--max-depth` limits how deep the expansion proceeds (0 disables expansion).
 * `--max-fanout` restricts the number of children added per node.
 * `--model` selects the OpenAI model to use (default `gpt-4o-mini`).
+* `--sys-prompt-file` appends the contents of a file to the system prompt.
+
+To append custom instructions to the system prompt:
+
+```bash
+python dag_generator.py "root node" --sys-prompt-file extra_prompt.txt
+```
 
 During execution the script prints a live status to stderr showing the
 current layer being expanded and the number of nodes remaining in that


### PR DESCRIPTION
## Summary
- add `--sys-prompt-file` flag to append custom text to the system prompt
- support optional system prompt append in DAG generation internals
- document new flag and usage

## Testing
- `python -m py_compile dag_generator.py`
- `python dag_generator.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68c080ef16e4832491cdfa73dccdd127