### PR TITLE
Prefix node IDs with axiom_node_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ python dag_generator.py "root node"
 ```
 
 Each positional argument is treated as the text for a seed node. The script
-assigns simple numeric identifiers starting at `0` so you no longer need to
-specify an ID. You can also provide a seed prompt from a file using the
-`--seed-file` flag. The entire contents of the file are treated as a single seed
-node:
+assigns sequential identifiers prefixed with `axiom_node_id-` starting at `0` so
+you no longer need to specify an ID. You can also provide a seed prompt from a
+file using the `--seed-file` flag. The entire contents of the file are treated
+as a single seed node:
 
 ```bash
 python dag_generator.py --seed-file seeds.txt

--- a/dag_generator.py
+++ b/dag_generator.py
@@ -16,16 +16,16 @@ except ImportError:
 _LOG_DIR: Optional[Path] = None
 _RESPONSE_COUNT = 0
 
-# Counter used to assign simple numeric IDs to nodes
+# Counter used to assign sequential IDs to nodes
 _NODE_COUNTER = 0
 
 
 def _next_id() -> str:
-    """Return a new sequential node id as a string."""
+    """Return a new sequential node id prefixed with ``axiom_node_id-``."""
     global _NODE_COUNTER
-    node_id = str(_NODE_COUNTER)
+    node_id = _NODE_COUNTER
     _NODE_COUNTER += 1
-    return node_id
+    return f"axiom_node_id-{node_id}"
 
 
 @dataclass
@@ -183,13 +183,13 @@ def make_system_prompt(
     max_fanout: Optional[int], append: Optional[str] = None
 ) -> str:
     prompt = (
-        "You expand nodes in a directed acyclic graph. Each node has a numeric"
-        " 'id' and some 'text'. When responding, reference parent nodes by their"
-        " 'node_id'. For new children, provide only the 'text'; IDs will be"
-        " assigned automatically. Use the 'stop_expansion' function when no"
-        " further ideas are needed. Use 'new_edges' to suggest new child nodes to"
-        " explore. For each node, call exactly one function: either 'new_edges' or"
-        " 'stop_expansion'."
+        "You expand nodes in a directed acyclic graph. Each node has an 'id' in the"
+        " form 'axiom_node_id-<number>' and some 'text'. When responding, reference"
+        " parent nodes by their 'node_id'. For new children, provide only the"
+        " 'text'; IDs will be assigned automatically. Use the 'stop_expansion'"
+        " function when no further ideas are needed. Use 'new_edges' to suggest new"
+        " child nodes to explore. For each node, call exactly one function: either"
+        " 'new_edges' or 'stop_expansion'."
     )
     if max_fanout is not None:
         prompt += f" Do not propose more than {max_fanout} child nodes per parent."


### PR DESCRIPTION
## Summary
- prefix generated node IDs with `axiom_node_id-`
- clarify ID format in system prompt and documentation

## Testing
- `python -m py_compile dag_generator.py`
- `python - <<'PY'
import dag_generator
print(dag_generator._next_id())
print(dag_generator._next_id())
PY`

------
https://chatgpt.com/codex/tasks/task_e_68c5d67ff98c8324b9c173c92240a7a3