### PR TITLE
feat: allow separate initial fanout

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ python dag_generator.py "root node" --max-depth 3 --max-fanout 2
 
 * `--max-depth` limits how deep the expansion proceeds (0 disables expansion).
 * `--max-fanout` restricts the number of children added per node.
+* `--initial-fanout` caps the number of children added for the seed layer only.
 * `--model` selects the OpenAI model to use (default `gpt-4o-mini`).
 * `--sys-prompt-file` appends the contents of a file to the system prompt.
 


### PR DESCRIPTION
## Summary
- add `--initial-fanout` CLI argument
- allow different fanout for initial layer from subsequent layers
- document new option in README

## Testing
- `python -m py_compile dag_generator.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6e59bfe208324954c8aec5cfab390