### PR TITLE
Add reasoning-effort and service-tier CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ python dag_generator.py "root node" --max-depth 3 --max-fanout 2
 * `--initial-fanout` caps the number of children added for the seed layer only.
 * `--model` selects the OpenAI model to use (default `gpt-4o-mini`).
 * `--sys-prompt-file` appends the contents of a file to the system prompt.
+* `--reasoning-effort` forwards a reasoning effort value to the OpenAI API.
+* `--service-tier` sets the service tier used for API requests.
 
 To append custom instructions to the system prompt:
 


### PR DESCRIPTION
## Summary
- allow configuring reasoning effort and service tier via new CLI flags
- pass these options through DAG generation so they reach the OpenAI responses call
- document new flags in README

## Testing
- `python -m py_compile dag_generator.py`
- `python dag_generator.py --help`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c6f7e70e00832494867fa0367ca6a5