### PR TITLE
Persist final DAG output

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,4 +47,6 @@ python dag_generator.py "root node" --sys-prompt-file extra_prompt.txt
 
 During execution the script prints a live status to stderr showing the
 current layer being expanded and the number of nodes remaining in that
-layer.
+layer. The final tree is written to standard output *and* persisted to
+`openai_outputs/<timestamp>/final_tree.json` alongside the raw response
+logs for later inspection.


### PR DESCRIPTION
## Summary
- ensure the OpenAI output directory is created lazily via a shared helper
- persist the final nested DAG JSON to the response output directory
- document where the final tree is saved alongside response logs

## Testing
- python -m compileall dag_generator.py

------
https://chatgpt.com/codex/tasks/task_e_68c8657722008324b9c9d74801d6273c