### PR TITLE
Enforce forced fanout semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ echo "root node" | python dag_generator.py --seed-stdin
 You can further control the graph generation using additional flags:
 
 ```bash
-python dag_generator.py "root node" --max-depth 3 --max-fanout 2
+python dag_generator.py "root node" --max-depth 3 --forced-fanout 2
 ```
 
 * `--max-depth` limits how deep the expansion proceeds (0 disables expansion).
-* `--max-fanout` restricts the number of children added per node.
-* `--initial-fanout` caps the number of children added for the seed layer only.
+* `--forced-fanout` enforces that each expanded node yields exactly the given number of children (alias: `--max-fanout`).
+* `--initial-forced-fanout` enforces the same restriction for only the seed layer (alias: `--initial-fanout`).
 * `--model` selects the OpenAI model to use (default `gpt-4o-mini`).
 * `--sys-prompt-file` appends the contents of a file to the system prompt.
 * `--reasoning-effort` forwards a reasoning effort value to the OpenAI API.


### PR DESCRIPTION
## Summary
- enforce forced fanout behavior by updating the system prompt, tool schema, and runtime validation to require exact child counts
- update DAG generation to use forced fanout values (including seed-layer overrides) and expose the behavior via new CLI aliases
- refresh the README to describe the forced fanout options and their semantics

## Testing
- python -m compileall dag_generator.py

------
https://chatgpt.com/codex/tasks/task_e_68cb8a19852c832483b67cc1acc757f2