### PR TITLE
Add CLI flag for OpenAI request timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ python dag_generator.py "root node" --max-depth 3 --forced-fanout 2
 * `--forced-fanout` enforces that each expanded node yields exactly the given number of children (alias: `--max-fanout`).
 * `--initial-forced-fanout` enforces the same restriction for only the seed layer (alias: `--initial-fanout`).
 * `--model` selects the OpenAI model to use (default `gpt-4o-mini`).
+* `--request-timeout` sets the OpenAI request timeout in seconds (overrides the `OPENAI_REQUEST_TIMEOUT` environment variable).
 * `--sys-prompt-file` appends the contents of a file to the system prompt.
 * `--reasoning-effort` forwards a reasoning effort value to the OpenAI API.
 * `--service-tier` sets the service tier used for API requests.

--- a/dag_generator.py
+++ b/dag_generator.py
@@ -727,6 +727,15 @@ def main() -> None:
         help="OpenAI model to use",
     )
     parser.add_argument(
+        "--request-timeout",
+        type=float,
+        default=None,
+        help=(
+            "Request timeout in seconds for OpenAI API calls. Overrides the "
+            "OPENAI_REQUEST_TIMEOUT environment variable."
+        ),
+    )
+    parser.add_argument(
         "--sys-prompt-file",
         type=argparse.FileType("r"),
         help="File whose contents are appended to the system prompt",
@@ -740,6 +749,11 @@ def main() -> None:
         help="Service tier value forwarded to the OpenAI API",
     )
     args = parser.parse_args()
+
+    if args.request_timeout is not None:
+        value = max(0.0, float(args.request_timeout))
+        global _OPENAI_REQUEST_TIMEOUT
+        _OPENAI_REQUEST_TIMEOUT = value
 
     def parse_seed(s: str) -> Node:
         return Node(_next_id(), s.strip())


### PR DESCRIPTION
## Summary
- add a --request-timeout CLI option so the OpenAI request timeout can be configured without touching environment variables
- document the new flag in the README alongside the other command-line options

## Testing
- python -m compileall dag_generator.py

------
https://chatgpt.com/codex/tasks/task_e_68cd94eb093c8324bf40e2cbccfe7f2a