### PR TITLE
Stop expanding flows once the max depth is reached

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,10 @@ You can further control the graph generation using additional flags:
 python dag_generator.py "root node" --max-depth 3 --forced-fanout 2
 ```
 
-* `--max-depth` limits how deep the expansion proceeds (0 disables expansion).
+* `--max-depth` limits how deep the expansion proceeds. The value counts the
+  total number of layers (including the seed layer); values <= 1 keep only the
+  seed layer, 0 disables expansion, and nodes at the maximum depth are treated
+  as leaves.
 * `--forced-fanout` enforces that each expanded node yields exactly the given number of children (alias: `--max-fanout`).
 * `--initial-forced-fanout` enforces the same restriction for only the seed layer (alias: `--initial-fanout`).
 * `--model` selects the OpenAI model to use (default `gpt-4o-mini`).


### PR DESCRIPTION
## Summary
- avoid scheduling additional expansions for nodes once the configured max depth is reached so flows stop cleanly
- track a stop-depth threshold in the DAG builder to prevent unnecessary OpenAI calls when no depth budget remains
- clarify the `--max-depth` documentation and CLI help text to describe the updated semantics

## Testing
- python -m py_compile dag_generator.py

------
https://chatgpt.com/codex/tasks/task_e_68cd9fbd865083249c276015a4460333